### PR TITLE
Use native language translations

### DIFF
--- a/translations/bs/languages.yml
+++ b/translations/bs/languages.yml
@@ -1,4 +1,4 @@
-en: Engleski
+en: English
 bs: Bosanski
 hr: Hrvatski
-sr: Srpski
+sr: Српски

--- a/translations/en/languages.yml
+++ b/translations/en/languages.yml
@@ -1,3 +1,3 @@
-bs: Bosnian
-sr: Serbian
-hr: Croatian
+bs: Bosanski
+sr: Српски
+hr: Hrvatski

--- a/translations/hr/languages.yml
+++ b/translations/hr/languages.yml
@@ -1,4 +1,4 @@
-en: Engleski
+en: English
 bs: Bosanski
 hr: Hrvatski
-sr: Srpski
+sr: Српски

--- a/translations/sr/languages.yml
+++ b/translations/sr/languages.yml
@@ -1,4 +1,4 @@
-en: Енглески
-bs: Босански
-hr: Хрватски
+en: English
+bs: Bosanski
+hr: Hrvatski
 sr: Српски


### PR DESCRIPTION
This is completely optional, but typically the language names are shown in their native form, no matter what the currently-selected language is. So the "languages" translations are a special case - not actually translations, and usually identical across the languages. But it is up to your preference; feel free to close if it's not appropriate here.