### PR TITLE
Example of using graph titles instead of disaggregation

### DIFF
--- a/data/indicator_2-1-1.csv
+++ b/data/indicator_2-1-1.csv
@@ -1,22 +1,22 @@
-Year,Units,Series,Value
-2001,Millions,Number of undernourish people,0.1
-2002,Millions,Number of undernourish people,0.1
-2003,Millions,Number of undernourish people,0.1
-2001,%,Prevalence of undernourishment,3.2
-2002,%,Prevalence of undernourishment,3.1
-2003,%,Prevalence of undernourishment,2.7
-2004,%,Prevalence of undernourishment,2.5
-2005,%,Prevalence of undernourishment,2.5
-2006,%,Prevalence of undernourishment,2.5
-2007,%,Prevalence of undernourishment,2.5
-2008,%,Prevalence of undernourishment,2.5
-2009,%,Prevalence of undernourishment,2.5
-2010,%,Prevalence of undernourishment,2.5
-2011,%,Prevalence of undernourishment,2.5
-2012,%,Prevalence of undernourishment,2.5
-2013,%,Prevalence of undernourishment,2.5
-2014,%,Prevalence of undernourishment,2.5
-2015,%,Prevalence of undernourishment,2.5
-2016,%,Prevalence of undernourishment,2.5
-2017,%,Prevalence of undernourishment,2.5
-2018,%,Prevalence of undernourishment,2.5
+Year,Units,Value
+2001,Millions,0.1
+2002,Millions,0.1
+2003,Millions,0.1
+2001,%,3.2
+2002,%,3.1
+2003,%,2.7
+2004,%,2.5
+2005,%,2.5
+2006,%,2.5
+2007,%,2.5
+2008,%,2.5
+2009,%,2.5
+2010,%,2.5
+2011,%,2.5
+2012,%,2.5
+2013,%,2.5
+2014,%,2.5
+2015,%,2.5
+2016,%,2.5
+2017,%,2.5
+2018,%,2.5

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -5,6 +5,11 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-01.pdf'
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
 graph_title: global_indicators.2-1-1-title
+graph_titles:
+    - unit: Millions
+      title: Number of undernourish people
+    - unit: '%'
+      title: Prevalence of undernourishment
 graph_type: line
 indicator_name: global_indicators.2-1-1-title
 indicator_sort_order: 02-01-01


### PR DESCRIPTION
This is an example of having dynamic graph titles, depending on the unit of measurement. In this case I think that the "Series" column could be removed.

If you like this approach, a next step would be to use translation keys instead of hardcoding "Number of undernourish people" and  "Prevalence of undernourishment".

More info on the "graph_titles" setting: https://open-sdg.readthedocs.io/en/latest/metadata-format/#mandatory-for-statistical-indicators