### PR TITLE
Disaggregation report config updates

### DIFF
--- a/config_data.yml
+++ b/config_data.yml
@@ -109,6 +109,12 @@ docs_intro: This is a list of examples of endpoints and output that are
 # This can be uncommented and updated so allow links to your indicator pages.
 # The URL here should have [id] instead of the indicator ID.
 docs_indicator_url: https://sdgbosnia.co.uk/[id]
+# This shows the translations in the disaggregation report.
+docs_translate_disaggregations: true
+# This includes additional columns in the disaggregation report.
+docs_extra_disaggregations:
+  - UNIT_MEASURE
+  - SERIES
 
 indicator_options:
   non_disaggregation_columns:


### PR DESCRIPTION
This updates the config according to the latest code:
1. Show translated columns in the disaggregation report (it was already doing this, although it is now optional)
2. Include UNIT_MEASURE and SERIES in the disaggregation report. This is important if the disaggregation report is to be used as a "cheat sheet" during data entry.